### PR TITLE
Update HW01 README.md to clarify .csv

### DIFF
--- a/homeworks/homework01/README.md
+++ b/homeworks/homework01/README.md
@@ -76,7 +76,7 @@ This question assesses your understanding of tidy data principles.
 
 Clean up the file that was originally named `Survey Data.xlsx`. Some points to remember: aim for a single tidy data frame in a single tab, don't use formatting as data, use preferred date format, properly record null values.
 
-Export this as a tab-delimited `.csv` text file with Unix line endings.
+Export this as a comma-delimited `.csv` text file.
 
 Commit the modified `.xlsx` file and the `.csv` file and publish to your public GitHub repository.
 


### PR DESCRIPTION
Phrasing "tab-delimited .csv text file with unix endings" is needlessly confusing. Instead, changing to "comma-delimited '.csv' text file", since I've gotten several questions about (1) a tab-delimited csv means [I know it's kosher phrasing, but still not the point of the hw] and (2) students needlessly editing in/out carriage returns from the ends of lines.